### PR TITLE
Make random more random and slightly easier to jump in to

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+go-esperanto
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: clean
+.DEFAULT_GOAL := all
+
+all: test build run
+
+test:
+	@go test .
+
+build:
+	@go build -mod=vendor .
+
+run:
+	@GO_EO_API_PORT=8081 \
+	GO_EO_AUTHTOKEN=randomtokenforapi \
+	./go-esperanto
+
+clean:
+	rm -rf ./go-esperanto

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A short program with RESTful API to randomly give an Esperanto word and translation. Mostly a proof of concept and a toy.
 
+Esperanto is the world's most widely spoken constructed international auxiliary language intended to be a universal second language for international communication.
+
 Phrasebook converted from Paul Denisowski's ESPDIC Project at <http://www.denisowski.org/Esperanto/ESPDIC/espdic.txt>
 
 ## Versioning
@@ -26,19 +28,26 @@ post body or the query string. If not specified, a random MD5 token will be gene
 Currently, only supports flat file storage; eventually may expand to other storage mechanisms.
 
 ## Running
+Setup:
 
-`go build -mod=vendor .`
+`make`
 
-`GO_EO_API_PORT=8081 GO_EO_AUTHTOKEN=randomtokenforapi ./go-esperanto`
-
+or
 ```bash
-curl http://localhost:8081/
+go build -mod=vendor .
+GO_EO_API_PORT=8081 GO_EO_AUTHTOKEN=randomtokenforapi ./go-esperanto
+```
+
+Get entire dictionary:
+```bash
+curl -H "X-API-TOKEN:randomtokenforapi" http://localhost:8081/
 
 [{"esperanto":"Gxis la revido","english":"Goodbye"}, ....]
 ```
 
+Get random phrase:
 ```bash
-curl http://localhost:8081/random
+curl -H "X-API-TOKEN:randomtokenforapi" http://localhost:8081/random
 
 {"esperanto":"Gxis la revido","english":"Goodbye"}
 ```

--- a/routes.go
+++ b/routes.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math/rand"
 	"net/http"
+	"time"
 )
 
 // GetAllPhrasesRoute gets all the phrases for the system
@@ -24,6 +25,8 @@ func GetRandomPhraseRoute(w http.ResponseWriter, r *http.Request) {
 		sendError(w, http.StatusForbidden, "bad token or no token found; ensure it is passed in the X-API-TOKEN header")
 		return
 	}
+    // use a seed to get better random number
+	rand.Seed(time.Now().UnixNano())
 	randID := rand.Intn(len(phrases))
 	p := phrases[randID]
 	sendResponse(w, http.StatusOK, p)
@@ -52,6 +55,8 @@ func sendResponse(w http.ResponseWriter, httpCode int, payload interface{}) {
 		Data: payload,
 	}
 	response, _ := json.Marshal(ret)
+	// add new line for nicer terminal output
+	response = append(response, []byte("\n")[0])
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpCode)
 	w.Write(response)


### PR DESCRIPTION
Hello there,
I'm poking around repos for Hacktoberfest and came across your `go-esperanto` project.

I had never heard of Esperanto before and found it to be an interesting concept of a unified language. After reading a bit online I wanted to learn more so I ran `go-esperanto` locally and enjoyed it and wanted to contribute a little back.

- Added a Makefile to be able to test, build, and run with one command. (GNU make is available by default on most *nix systems)
- Add a line to README to explain what Esperanto is for those who are unaware.
- Clarified in README how to pass the X-API-TOKEN header.
- Added a new line to the router response so it is a bit cleaner on the terminal.
- Added a rand seed to get a better random phrase as I noticed I would get some of the same ones often from such a bit dictionary.

Thank you for your time.
